### PR TITLE
change vc login route to what mobile expects

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -11,5 +11,5 @@ const router = express.Router();
 
 router.post('/login', requestLogger, userController.login);
 router.post('/login/azure', requestLogger, userController.loginAzure);
-router.post('/login/loginWithCredential', requestLogger, userController.loginWithVC);
+router.post('/loginWithCredential', requestLogger, userController.loginWithVC);
 module.exports = router;


### PR DESCRIPTION
The mobile verifiers expect the Verifier Configuration login endpoint to be `/loginWithCredential`.