### PR TITLE
change qr code options to make easier scanning

### DIFF
--- a/controllers/credential.js
+++ b/controllers/credential.js
@@ -18,11 +18,8 @@ const logger = require('../utils/logger').getLogger(
 );
 
 const qrCodeOptions = {
-    errorCorrectionLevel: 'M',
-    type: 'png',
-    quality: 0.92,
-    margin: 10,
-    width: 300,
+    scale: 2,
+    errorCorrectionLevel: 'L',
 }
 
 const getCredentailFormat = (type) => {


### PR DESCRIPTION
Changes the qr code options to make scanning easier.  These are the same options as the old hpass API.